### PR TITLE
added likes and likeCount to model and controller

### DIFF
--- a/server/models/post.model.js
+++ b/server/models/post.model.js
@@ -11,8 +11,10 @@ const PostSchema = new mongoose.Schema({
     postImages: {
         type: [String]
     },
+    // Model ideas: https://stackoverflow.com/questions/28006521/how-to-model-a-likes-voting-system-with-mongodb
+    likeCount: { type: Number, default: 0 },
     likes: [],
-    comments: []
+    comments: [] // will likely need to create a separate comments model so users can reply in comment threads
 }, { timestamps: true });
 
 module.exports = mongoose.model('Post', PostSchema);

--- a/server/routes/artchive.routes.js
+++ b/server/routes/artchive.routes.js
@@ -35,4 +35,5 @@ module.exports = (app) => {
     app.get('/api/posts/:id', authenticate, getIdFromCookie, PostController.findPostById);
     app.patch('/api/posts/:id', authenticate, getIdFromCookie, PostController.updatePost);
     app.delete('/api/posts/:id', authenticate, getIdFromCookie, PostController.deletePost);
+    app.patch('/api/likepost/:id', authenticate, getIdFromCookie, PostController.likePost);
 }


### PR DESCRIPTION
Tested on Postman, users should be able to like each post with the route (/api/likepost/:postId) once using the current logic in the controller. I still need to implement a remove-like route, and we will have to decide how we want to build the logic for checking if a post has already been liked upon page load.